### PR TITLE
fix: autoescape for non-string values

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -97,11 +97,11 @@ var filters = {
     },
 
     escape: function(str) {
-        if(typeof str === 'string' ||
-           str instanceof r.SafeString) {
-            return lib.escape(str);
+        if (str == null) str = '';
+        if(str instanceof r.SafeString) {
+            return str;
         }
-        return str;
+        return r.markSafe(lib.escape(str.toString()));
     },
 
     safe: function(str) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -199,8 +199,8 @@ function markSafe(val) {
 function suppressValue(val, autoescape) {
     val = (val !== undefined && val !== null) ? val : '';
 
-    if(autoescape && typeof val === 'string') {
-        val = lib.escape(val);
+    if(autoescape && !(val instanceof SafeString)) {
+        val = lib.escape(val.toString());
     }
 
     return val;

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -420,5 +420,17 @@
             equal('{{ "foo bar baz" | wordcount }}', '3');
             finish(done);
         });
+
+        it('should work with non-string values', function(done) {
+            equal('{{ foo | escape }}', {foo: null}, '');
+            equal('{{ foo | escape }}', {foo: ['<html>']}, '&lt;html&gt;');
+            render('{{ foo }}', { foo: {toString: function() {return '<p>foo</p>'}}}, { autoescape: true }, function(err, res) {
+                expect(res).to.be('&lt;p&gt;foo&lt;/p&gt;');
+            });
+            render('{{ foo }}', { foo: {toString: function() {return '<p>foo</p>'}}}, { autoescape: false }, function(err, res) {
+                expect(res).to.be('<p>foo</p>');
+            });
+            finish(done);
+        });
     });
 })();


### PR DESCRIPTION
pick from https://github.com/mozilla/nunjucks/pull/836
